### PR TITLE
ci: update stevezhu/actions to v1

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   bump-version:
-    uses: stevezhu/actions/.github/workflows/npm-bump-version.yaml@v1.0.1
+    uses: stevezhu/actions/.github/workflows/npm-bump-version.yaml@v1
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   ci:
-    uses: stevezhu/actions/.github/workflows/ci-node.yaml@v1.0.1
+    uses: stevezhu/actions/.github/workflows/ci-node.yaml@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    uses: stevezhu/actions/.github/workflows/npm-publish.yaml@v1.0.1
+    uses: stevezhu/actions/.github/workflows/npm-publish.yaml@v1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Updates stevezhu/actions usages to point to v1 tag for stability.