### PR TITLE
fix: remove exactOptionalPropertyTypes from base config

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
## Summary
- Removes `exactOptionalPropertyTypes: true` from `tsconfig.base.json` as it causes issues in downstream projects consuming these shared configs

## Test plan
- [ ] Verify downstream projects compile without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)